### PR TITLE
[update] make component colors intaractive

### DIFF
--- a/st_img_pastebutton/frontend/src/MyComponent.tsx
+++ b/st_img_pastebutton/frontend/src/MyComponent.tsx
@@ -3,6 +3,7 @@ import {
   Streamlit,
   StreamlitComponentBase,
   withStreamlitConnection,
+  Theme,
 } from "streamlit-component-lib";
 
 interface State {
@@ -49,15 +50,16 @@ class ImageClipboardComponent extends StreamlitComponentBase<State> {
     }
   };
 
-  public render = (): React.ReactNode => {  
+  public render = (): React.ReactNode => {
     const label = String(this.props.args["label"])
     const { error } = this.state;
+    const theme: Theme | undefined = this.props.theme;
 
     const buttonStyle = {
-      backgroundColor: "#ffffff",
-      color: "black",
+      backgroundColor: "transparent",
+      color: theme.textColor,
       padding: "5px 10px",
-      border: "1px solid #cccccc",
+      border: `1px solid ${theme.secondaryBackgroundColor}`,
       borderRadius: "8px",
       cursor: "pointer",
       fontSize: "14px",
@@ -69,8 +71,8 @@ class ImageClipboardComponent extends StreamlitComponentBase<State> {
     };
 
     const buttonHoverStyle = {
-      color: "red",
-      borderColor: "red",
+      color: theme.primaryColor,
+      borderColor: theme.primaryColor,
     };
 
     return (
@@ -90,7 +92,7 @@ class ImageClipboardComponent extends StreamlitComponentBase<State> {
         {error && <div style={{ color: "red" }}>{error}</div>}
       </div>
     );
-  };  
+  };
 }
 
 export default withStreamlitConnection(ImageClipboardComponent);


### PR DESCRIPTION
背景を透過させ、[ここ](https://github.com/streamlit/streamlit/blob/152993c2f022ee3ea086f1d06798c2460fd8b5c4/component-lib/src/streamlit.ts#L241) をヒントにテキストやボーダーの色を設定しました。ご確認いただけますと幸いです。

* close #1 

![image](https://github.com/tsuzukia21/st-img-pastebutton/assets/63488322/5d9ebfe6-b1ef-4d69-96d1-e735bc228dea)
![image](https://github.com/tsuzukia21/st-img-pastebutton/assets/63488322/1b1138a3-278e-4b87-b635-53bddf23e912)
![image](https://github.com/tsuzukia21/st-img-pastebutton/assets/63488322/fb6950ab-b9e3-465f-910a-bb72ada40d1e)
![image](https://github.com/tsuzukia21/st-img-pastebutton/assets/63488322/d52aa903-d155-4eca-b331-f3d29fed303e)